### PR TITLE
Fix getFavorite function to use findOne instead of find

### DIFF
--- a/services/houses/favorite/favoriteService.js
+++ b/services/houses/favorite/favoriteService.js
@@ -22,7 +22,7 @@ const createFavorite = async (userId, houseId) => {
 // get one favor
 const getFavorite = async (userId, houseId) => {
   try {
-    const favoriteHouse = await FavoriteModel.find({
+    const favoriteHouse = await FavoriteModel.findOne({
       user: userId,
       house: houseId,
     })


### PR DESCRIPTION
This pull request fixes the getFavorite function in the code to use the findOne method instead of the find method. This change ensures that only one favorite house is returned for the given user and house IDs.